### PR TITLE
Match both https and http for gitorious and github.

### DIFF
--- a/agit/AndroidManifest.xml
+++ b/agit/AndroidManifest.xml
@@ -95,6 +95,7 @@
 				<category android:name="android.intent.category.BROWSABLE"></category>
                 <action android:name="android.intent.action.VIEW"></action>
 				<data android:host="github.com" android:scheme="https" android:pathPattern="/.*/.*" />
+				<data android:host="github.com" android:scheme="http" android:pathPattern="/.*/.*" />
 			</intent-filter>
 		</activity>
 
@@ -103,6 +104,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
 				<category android:name="android.intent.category.BROWSABLE"></category>
                 <action android:name="android.intent.action.VIEW"></action>
+				<data android:host="gitorious.org" android:scheme="https" android:pathPattern="/.*/.*" />
 				<data android:host="gitorious.org" android:scheme="http" android:pathPattern="/.*/.*" />
 			</intent-filter>
 		</activity>


### PR DESCRIPTION
I noticed that my link to http://github.com/.../... didn't match, seemingly because Agit is looking for https. Looks like it would have the opposite problem for gitorious? I haven't tested this change at all. :-) Other than that, nice app, thanks.
