### PR TITLE
Make sure only the repository owner and name are taken from the GitHub path

### DIFF
--- a/agit/src/main/java/com/madgag/agit/weblaunchers/GitHubWebLaunchActivity.java
+++ b/agit/src/main/java/com/madgag/agit/weblaunchers/GitHubWebLaunchActivity.java
@@ -13,8 +13,11 @@ public class GitHubWebLaunchActivity extends WebLaunchActivity {
     private static final String TAG = "WL-github";
 
     Intent cloneLauncherForWebBrowseIntent(Uri uri) {
-        return cloneLauncherIntentFor("git://github.com"+ uri.getPath() +".git");
+        final String[] pathParts = uri.getPath().split("/");
+        String path = uri.getPath();
+        if (pathParts.length >= 2) {
+            path = pathParts[0] + "/" + pathParts[1];
+        }
+        return cloneLauncherIntentFor("git://github.com/"+ path +".git");
     }
-
-
 }


### PR DESCRIPTION
I noticed that Agit will accept URLs such as https://github.com/eddieringle/hubroid/issues/66 and attempt to turn it into a Git URL. I haven't actually tried fetching from one of these URLs yet, but it doesn't look pretty. This patch should only use the first two segments from the path to form the Git URL.

I wasn't able to build or test, but things should be in order.
