### PR TITLE
Added Polish translation

### DIFF
--- a/agit/res/values-pl/pulltorefresh_strings.xml
+++ b/agit/res/values-pl/pulltorefresh_strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="pull_to_refresh_pull_label">Pull to refresh...</string>
+    <string name="pull_to_refresh_release_label">Puść aby odświeżyć...</string>
+    <string name="pull_to_refresh_refreshing_label">Ładuję...</string>
+    <string name="pull_to_refresh_tap_label">Tapnij aby odświeżyć...</string>
+</resources>
+

--- a/agit/res/values-pl/pulltorefresh_strings.xml
+++ b/agit/res/values-pl/pulltorefresh_strings.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="pull_to_refresh_pull_label">Pull to refresh...</string>
+    <string name="pull_to_refresh_pull_label">Pociągnij aby odświeżyć...</string>
     <string name="pull_to_refresh_release_label">Puść aby odświeżyć...</string>
     <string name="pull_to_refresh_refreshing_label">Ładuję...</string>
-    <string name="pull_to_refresh_tap_label">Tapnij aby odświeżyć...</string>
+    <string name="pull_to_refresh_tap_label">Dotknij aby odświeżyć...</string>
 </resources>
 

--- a/agit/res/values-pl/strings.xml
+++ b/agit/res/values-pl/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="app_name">Agit</string>
     <string name="app_strap">Android Git Client</string>
-    <string name="suggest_repos_button">Zasugeruj repozytoria...</string>
     <string name="about_app_menu_option">O programie</string>
     <string name="about_activity_title">O programie...</string>
     <string name="using_ssh_activity_title">Podręcznik instalacji SSH</string>
@@ -10,8 +9,8 @@
     <string name="clone_menu_option">Sklonuj...</string>
     <string name="enter_clone_url">URL</string>
     <string name="clone_target_folder_label">Folder docelowy</string>
-    <string name="clone_url_hint">URL repozytorium</string>
-    <string name="clone_directory_hint">Folder, w którym zostanie zapisane repo</string>
+    <string name="clone_url_hint">Adres repozytorium</string>
+    <string name="clone_directory_hint">Folder, w którym zostanie zapisane repozytorium</string>
     <string name="clone_readiness_needs_user_to_enter_a_url">Podaj adres repozytorium - lub wybierz jedno z #suggest_repo[przykładowych].</string>
     <string name="clone_readiness_folder_already_exists">Folder już istnieje - czy chcesz #specify_target_dir[określić alternatywną] lokalizację?</string>
     <string name="clone_readiness_repository_folder_already_exists">Folder istnieje lokalnie - czy chcesz zobaczyć #view_existing_repo[istniejące repozytorium]?</string>
@@ -20,18 +19,18 @@
     <string name="repo_list_title">Repozytoria lokalne</string>
 
     <string name="use_default_target_directory_checkbox_label">Użyj domyślnej lokalizacji</string>
-    <string name="bare_repo_checkbox_label">Bare</string>
+    <string name="bare_repo_checkbox_label">Bare (bez katalogu roboczego)</string>
 
 
     <string name="execute_clone_button_label">Klonuj!</string>
     <string name="delete_repo_menu_option">Usuń repozytorium</string>
-    <string name="delete_tag_menu_option">Usuń Tag</string>
+    <string name="delete_tag_menu_option">Usuń tag</string>
 
-    <string name="latest_commit_title">Ostatni Commit</string>
+    <string name="latest_commit_title">Ostatni commit</string>
     <string name="empty_list">« brak »</string>
 
-    <string name="tag_name_label">Nazwa:</string>
-    <string name="tag_message_label">Wiadomość (opcjonalnie):</string>
+    <string name="tag_name_label">Name:</string>
+    <string name="tag_message_label">Message (optional):</string>
     <string name="checkout_commit_menu_option">Checkout...</string>
     <string name="tag_commit_menu_option">Tag...</string>
 

--- a/agit/res/values-pl/strings.xml
+++ b/agit/res/values-pl/strings.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Agit</string>
+    <string name="app_strap">Android Git Client</string>
+    <string name="suggest_repos_button">Zasugeruj repozytoria...</string>
+    <string name="about_app_menu_option">O programie</string>
+    <string name="about_activity_title">O programie...</string>
+    <string name="using_ssh_activity_title">Podręcznik instalacji SSH</string>
+    <string name="clone_launcher_activity_title">Klonowanie...</string>
+    <string name="clone_menu_option">Sklonuj...</string>
+    <string name="enter_clone_url">URL</string>
+    <string name="clone_target_folder_label">Folder docelowy</string>
+    <string name="clone_url_hint">URL repozytorium</string>
+    <string name="clone_directory_hint">Folder, w którym zostanie zapisane repo</string>
+    <string name="clone_readiness_needs_user_to_enter_a_url">Podaj adres repozytorium - lub wybierz jedno z #suggest_repo[przykładowych].</string>
+    <string name="clone_readiness_folder_already_exists">Folder już istnieje - czy chcesz #specify_target_dir[określić alternatywną] lokalizację?</string>
+    <string name="clone_readiness_repository_folder_already_exists">Folder istnieje lokalnie - czy chcesz zobaczyć #view_existing_repo[istniejące repozytorium]?</string>
+    <string name="ssh_agent_not_correctly_installed">Niedostępny żaden klient SSH - sprawdź #view_ssh_instructions[podręcznik instalacji SSH]</string>
+
+    <string name="repo_list_title">Repozytoria lokalne</string>
+
+    <string name="use_default_target_directory_checkbox_label">Użyj domyślnej lokalizacji</string>
+    <string name="bare_repo_checkbox_label">Bare</string>
+
+
+    <string name="execute_clone_button_label">Klonuj!</string>
+    <string name="delete_repo_menu_option">Usuń repozytorium</string>
+    <string name="delete_tag_menu_option">Usuń Tag</string>
+
+    <string name="latest_commit_title">Ostatni Commit</string>
+    <string name="empty_list">« brak »</string>
+
+    <string name="tag_name_label">Nazwa:</string>
+    <string name="tag_message_label">Wiadomość (opcjonalnie):</string>
+    <string name="checkout_commit_menu_option">Checkout...</string>
+    <string name="tag_commit_menu_option">Tag...</string>
+
+    <string name="clone_launcher_farewell_due_to_clone_launched">Klonowanie rozpoczęte!</string>
+    <string name="object_id_copied">Obiekt o id<br /><small><b><tt>%s</tt></b></small><br />skopiowany do schowka!</string>
+
+    <string name="ask_host_key_ok_ticker" >"Odcisk klucza SSH z hosta %1$s..."</string>
+	<string name="ask_host_key_ok" >"%1$s ma odcisk klucza SSH: %2$s OK?"</string>
+
+    <string name="diff_seekbar_before">PRZED</string>
+    <string name="diff_seekbar_after">PO</string>
+</resources>


### PR DESCRIPTION
Hi!

As a big fan of Git I found your app for Android and gave it a try :)

I also prepared the basic translations to Polish in `strings.xml`. Though I couldn't find lots of phrases there, like:
_protocol:
fetch complete
fetch failed
fetching
fetched
clone cancelled
clone completed
password required 
please enter your password
deleting repo 
branches
tags_

If you could make them "translatable" I would further expand `strings.xml` file.

On the other hand I'm not sure where these keys appear in the app?
_suggest_repos_button
checkout_commit_menu_option
pull_to_refresh_pull_label
tag_message_label
tag_message_label
suggest_repos_button_

I think that `CREDITS.markdown` and `Using-SSH.markdown` also deserve translation. But am not sure how to name them (maybe `CREDITS.pl.markdown`) or alternatively where to put them?

The translation was not yet tested on the device - as I don't know how to compile the source... If you could send me a compiled .apk file based on this branch? And please don't merge it yet as probably there would be some fine-tuning needed.
