### PR TITLE
Update imports that were referencing non-local R strings.

### DIFF
--- a/agit/src/main/java/com/madgag/agit/operations/Clone.java
+++ b/agit/src/main/java/com/madgag/agit/operations/Clone.java
@@ -1,9 +1,7 @@
 package com.madgag.agit.operations;
 
-import android.content.Context;
 import android.util.Log;
 import com.google.inject.Inject;
-import com.madgag.android.listviews.pinnedheader.R;
 import org.eclipse.jgit.api.TransportConfigCallback;
 import org.eclipse.jgit.api.errors.JGitInternalException;
 import org.eclipse.jgit.transport.CredentialsProvider;
@@ -14,12 +12,11 @@ import java.io.File;
 
 import static android.R.drawable.stat_sys_download;
 import static android.R.drawable.stat_sys_download_done;
+import static com.madgag.agit.R.string.clone;
 import static com.madgag.agit.R.string.cloned_repo;
+import static com.madgag.agit.R.string.cloning_repo;
 import static com.madgag.agit.R.string.cloning;
-import static com.madgag.agit.R.string.fetching;
 import static com.madgag.agit.operations.JGitAPIExceptions.exceptionWithFriendlyMessageFor;
-import static com.madgag.android.listviews.pinnedheader.R.string.clone;
-import static com.madgag.android.listviews.pinnedheader.R.string.cloning_repo;
 import static org.eclipse.jgit.api.Git.cloneRepository;
 import static org.eclipse.jgit.lib.Constants.*;
 

--- a/agit/src/main/java/com/madgag/agit/operations/RepoDeleter.java
+++ b/agit/src/main/java/com/madgag/agit/operations/RepoDeleter.java
@@ -21,7 +21,6 @@ package com.madgag.agit.operations;
 
 import android.util.Log;
 import com.google.inject.Inject;
-import com.madgag.agit.R;
 import org.eclipse.jgit.lib.Repository;
 import roboguice.inject.InjectResource;
 
@@ -32,7 +31,6 @@ import static android.R.drawable.stat_sys_download;
 import static android.R.drawable.stat_sys_download_done;
 import static com.madgag.agit.R.string.delete_repo;
 import static com.madgag.agit.git.Repos.topDirectoryFor;
-import static com.madgag.android.listviews.pinnedheader.R.string.clone;
 import static org.apache.commons.io.FileUtils.deleteDirectory;
 
 public class RepoDeleter extends GitOperation {

--- a/agit/src/main/java/com/madgag/agit/ssh/CuriousHostKeyRepository.java
+++ b/agit/src/main/java/com/madgag/agit/ssh/CuriousHostKeyRepository.java
@@ -19,8 +19,8 @@ import static com.madgag.agit.operations.OpPrompt.promptYesOrNo;
 import static com.madgag.agit.util.DigestUtils.encodeHex;
 import static com.madgag.agit.util.DigestUtils.md5;
 import static com.madgag.agit.views.TextUtil.centered;
-import static com.madgag.android.listviews.pinnedheader.R.string.ask_host_key_ok;
-import static com.madgag.android.listviews.pinnedheader.R.string.ask_host_key_ok_ticker;
+import static com.madgag.agit.R.string.ask_host_key_ok;
+import static com.madgag.agit.R.string.ask_host_key_ok_ticker;
 import static java.lang.Boolean.TRUE;
 
 @Singleton


### PR DESCRIPTION
These were causing error markers in Eclipse as they seemed to reference
an R file in one of your other Android libraries (pinnedheader).
