### PR TITLE
Specify a version for maven-resources-plugin

### DIFF
--- a/agit/pom.xml
+++ b/agit/pom.xml
@@ -165,6 +165,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
+                <version>2.4.1</version>
                 <executions>
                     <execution>
                         <phase>initialize</phase>


### PR DESCRIPTION
Version should be fixed as far as agit can't be build
with recent versions of this plugin.

Fixes #78
