### PR TITLE
Issue 100: Add a settings menu with a single preference for controlling sync frequency.

### DIFF
--- a/CREDITS.markdown
+++ b/CREDITS.markdown
@@ -43,6 +43,8 @@ the alternative [Git logo](http://henrik.nyh.se/2007/06/alternative-git-logo-and
 
 *   Bernd Hirschler - [German Translation](https://github.com/rtyley/agit/pull/35)
 
+*   Scott Johnson - [Sync Frequency UI](https://github.com/rtyley/agit/pull/103)
+
 *   Eddie Ringle - [Tweak GitHub url parsing](https://github.com/rtyley/agit/pull/29)
 
 *   Leonardo Taglialegne - [Italian Translation](https://github.com/rtyley/agit/pull/46)

--- a/agit/AndroidManifest.xml
+++ b/agit/AndroidManifest.xml
@@ -148,6 +148,12 @@
 			</intent-filter>
 		</activity>
 
+        <receiver android:name=".sync.SyncRepoManager" android:exported="true">
+            <intent-filter>
+                <action android:name="com.madgag.agit.sync.SET_DAILY_SYNC" />
+            </intent-filter>
+        </receiver>
+
         <service android:name="GitOperationsService">
             <intent-filter>
                 <action android:name="org.openintents.git.repo.SYNC"/>
@@ -190,4 +196,5 @@
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS"/>
     <uses-permission android:name="android.permission.READ_SYNC_STATS"/>
     <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS"/>
+    <uses-permission android:name="android.permission.WAKE_LOCK"/>
 </manifest>

--- a/agit/AndroidManifest.xml
+++ b/agit/AndroidManifest.xml
@@ -15,6 +15,12 @@
             </intent-filter>
         </activity>
 
+        <activity android:name="SettingsActivity">
+            <intent-filter>
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
+        </activity>
+
         <activity android:name=".AboutUsingSshActivity">
             <intent-filter>
                 <category android:name="android.intent.category.DEFAULT"/>

--- a/agit/res/layout/settings_activity.xml
+++ b/agit/res/layout/settings_activity.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+                  android:title="@string/settings">
+
+    <PreferenceCategory
+            android:title="@string/settings_category_sync">
+
+        <EditTextPreference
+                android:key="setting_sync_frequency"
+                android:title="@string/setting_title_sync_frequency"
+                android:summary="@string/setting_instruction_sync_frequency"
+                android:inputType="number">
+        </EditTextPreference>
+
+    </PreferenceCategory>
+
+</PreferenceScreen>

--- a/agit/res/layout/settings_activity.xml
+++ b/agit/res/layout/settings_activity.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-                  android:title="@string/settings">
+<PreferenceScreen
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:title="@string/settings">
 
     <PreferenceCategory
             android:title="@string/settings_category_sync">
-
-        <EditTextPreference
-                android:key="setting_sync_frequency"
-                android:title="@string/setting_title_sync_frequency"
-                android:summary="@string/setting_instruction_sync_frequency"
-                android:inputType="number">
-        </EditTextPreference>
-
+        <ListPreference
+            android:key="setting_sync_frequency"
+            android:title="@string/setting_title_sync_frequency"
+            android:summary="@string/setting_instruction_sync_frequency"
+            android:entries="@array/setting_sync_choices"
+            android:entryValues="@array/setting_sync_choices_values"
+            android:dialogTitle="@string/setting_title_sync_frequency">
+         </ListPreference>
     </PreferenceCategory>
-
 </PreferenceScreen>

--- a/agit/res/layout/settings_activity.xml
+++ b/agit/res/layout/settings_activity.xml
@@ -6,7 +6,8 @@
     <PreferenceCategory
             android:title="@string/settings_category_sync">
         <ListPreference
-            android:key="setting_sync_frequency"
+            android:id="@+id/setting_sync_frequency_listPref"
+            android:key="@string/setting_sync_frequency_key"
             android:title="@string/setting_title_sync_frequency"
             android:summary="@string/setting_instruction_sync_frequency"
             android:entries="@array/setting_sync_choices"

--- a/agit/res/menu/dashboard.xml
+++ b/agit/res/menu/dashboard.xml
@@ -11,6 +11,11 @@
             android:showAsAction="never">
     </item>
     <item
+            android:id="@+id/settings"
+            android:showAsAction="never"
+            android:title="@string/settings_app_menu_option">
+    </item>
+    <item
             android:id="@+id/about_app"
             android:showAsAction="never"
             android:title="@string/about_app_menu_option">

--- a/agit/res/values/strings.xml
+++ b/agit/res/values/strings.xml
@@ -120,8 +120,7 @@
     <string name="setting_instruction_sync_frequency">Tap to set how often repository synchronization will occur</string>
     <string name="setting_sync_frequency_key">setting_sync_frequency</string>
 
-    <!-- This is a "magic number" just set so as not to confuse with other potential values -->
-    <string name="setting_sync_frequency_daily">72083</string>
+    <string name="setting_sync_frequency_daily">0</string>
     <string name="setting_sync_frequency_daily_title">Sync daily at</string>
     <string name="setting_sync_frequency_daily_hour_key">setting_sync_frequency_daily_hour</string>
     <string name="setting_sync_frequency_daily_min_key">setting_sync_frequency_daily_min</string>
@@ -136,7 +135,7 @@
         <item>Every 12 hours</item>
     </string-array>
     <string-array name="setting_sync_choices_values">
-        <item>0</item>
+        <item>-1</item>
         <item>@string/setting_sync_frequency_daily</item>
         <item>15</item>
         <item>60</item>

--- a/agit/res/values/strings.xml
+++ b/agit/res/values/strings.xml
@@ -124,25 +124,35 @@
     <string name="setting_sync_frequency_daily_title">Sync daily at</string>
     <string name="setting_sync_frequency_daily_hour_key">setting_sync_frequency_daily_hour</string>
     <string name="setting_sync_frequency_daily_min_key">setting_sync_frequency_daily_min</string>
+    <string name="setting_sync_frequency_subtitle_key">setting_sync_frequency_subtitle</string>
 
+    <!--
+         These next two arrays need to be in sync (no pun intended). In other words, if you change
+         setting_sync_choices to have another value, you need to put a corresponding integer value
+         into the setting_sync_choices_values
+      -->
     <string-array name="setting_sync_choices">
         <item>Manually</item>
         <item>Schedule daily at&#8230;</item>
+        <item>Every minute</item>
+        <item>Every 5 minutes</item>
         <item>Every 15 minutes</item>
         <item>Every hour</item>
-        <item>Every 3 hours</item>
-        <item>Every 6 hours</item>
-        <item>Every 12 hours</item>
+        <item>Every 4 hours</item>
+        <item>Every day</item>
+        <item>Every week</item>
     </string-array>
+
+    <!-- These next values are in MINUTES (except for the special values for "Manually" and "Sync Daily" -->
     <string-array name="setting_sync_choices_values">
         <item>-1</item>
         <item>@string/setting_sync_frequency_daily</item>
+        <item>1</item>
+        <item>5</item>
         <item>15</item>
         <item>60</item>
-        <item>180</item>
-        <item>360</item>
-        <item>720</item>
-        <!-- <item>Every week on&#8230;</item> -->
-        <!-- <item>Every month on&#8230;</item> -->
+        <item>240</item>
+        <item>1440</item>
+        <item>10080</item>
     </string-array>
 </resources>

--- a/agit/res/values/strings.xml
+++ b/agit/res/values/strings.xml
@@ -116,6 +116,26 @@
     <!-- Settings Strings -->
     <string name="settings">Settings</string>
     <string name="settings_category_sync">Sync Settings</string>
-    <string name="setting_title_sync_frequency">Sync Frequency (Minutes)</string>
+    <string name="setting_title_sync_frequency">Sync Frequency</string>
     <string name="setting_instruction_sync_frequency">Tap to set how often repository synchronization will occur</string>
+    <string-array name="setting_sync_choices">
+        <item>Manually</item>
+        <!-- <item>Schedule daily at&#8230;</item> -->
+        <item>Every 15 minutes</item>
+        <item>Every hour</item>
+        <item>Every 3 hours</item>
+        <item>Every 6 hours</item>
+        <item>Every 12 hours</item>
+    </string-array>
+    <string-array name="setting_sync_choices_values">
+        <item>0</item>
+        <!-- <item>1</item> -->
+        <item>15</item>
+        <item>60</item>
+        <item>180</item>
+        <item>360</item>
+        <item>720</item>
+        <!-- <item>Every week on&#8230;</item> -->
+        <!-- <item>Every month on&#8230;</item> -->
+    </string-array>
 </resources>

--- a/agit/res/values/strings.xml
+++ b/agit/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="using_ssh_activity_title">SSH Install Guide</string>
     <string name="clone_launcher_activity_title">Clone...</string>
     <string name="clone_menu_option">Clone...</string>
+    <string name="settings_app_menu_option">Settings...</string>
     <string name="enter_clone_url">Url</string>
     <string name="clone_target_folder_label">Target Folder</string>
     <string name="clone_url_hint">Repository url</string>
@@ -112,4 +113,9 @@
 
     <string name="no_viewer_available_for_file">"No viewer available for '%1$s'"</string>
 
+    <!-- Settings Strings -->
+    <string name="settings">Settings</string>
+    <string name="settings_category_sync">Sync Settings</string>
+    <string name="setting_title_sync_frequency">Sync Frequency (Minutes)</string>
+    <string name="setting_instruction_sync_frequency">Tap to set how often repository synchronization will occur</string>
 </resources>

--- a/agit/res/values/strings.xml
+++ b/agit/res/values/strings.xml
@@ -118,9 +118,17 @@
     <string name="settings_category_sync">Sync Settings</string>
     <string name="setting_title_sync_frequency">Sync Frequency</string>
     <string name="setting_instruction_sync_frequency">Tap to set how often repository synchronization will occur</string>
+    <string name="setting_sync_frequency_key">setting_sync_frequency</string>
+
+    <!-- This is a "magic number" just set so as not to confuse with other potential values -->
+    <string name="setting_sync_frequency_daily">72083</string>
+    <string name="setting_sync_frequency_daily_title">Sync daily at</string>
+    <string name="setting_sync_frequency_daily_hour_key">setting_sync_frequency_daily_hour</string>
+    <string name="setting_sync_frequency_daily_min_key">setting_sync_frequency_daily_min</string>
+
     <string-array name="setting_sync_choices">
         <item>Manually</item>
-        <!-- <item>Schedule daily at&#8230;</item> -->
+        <item>Schedule daily at&#8230;</item>
         <item>Every 15 minutes</item>
         <item>Every hour</item>
         <item>Every 3 hours</item>
@@ -129,7 +137,7 @@
     </string-array>
     <string-array name="setting_sync_choices_values">
         <item>0</item>
-        <!-- <item>1</item> -->
+        <item>@string/setting_sync_frequency_daily</item>
         <item>15</item>
         <item>60</item>
         <item>180</item>

--- a/agit/src/main/java/com/madgag/agit/DashboardActivity.java
+++ b/agit/src/main/java/com/madgag/agit/DashboardActivity.java
@@ -43,7 +43,6 @@ import android.widget.Toast;
 import com.actionbarsherlock.view.Menu;
 import com.actionbarsherlock.view.MenuItem;
 import com.github.rtyley.android.sherlock.roboguice.activity.RoboSherlockFragmentActivity;
-import com.madgag.android.IntentUtil;
 import com.madgag.android.util.store.InstallAppDialogFragment;
 
 import java.io.File;
@@ -80,6 +79,9 @@ public class DashboardActivity extends RoboSherlockFragmentActivity {
         switch (item.getItemId()) {
             case R.id.clone:
                 startActivity(new Intent(this, CloneLauncherActivity.class));
+                return true;
+            case R.id.settings:
+                startActivity(new Intent(this, SettingsActivity.class));
                 return true;
             case R.id.open_repo:
                 if (isIntentAvailable(this, PICK_DIRECTORY_INTENT)) {

--- a/agit/src/main/java/com/madgag/agit/SettingsActivity.java
+++ b/agit/src/main/java/com/madgag/agit/SettingsActivity.java
@@ -20,14 +20,56 @@
 package com.madgag.agit;
 
 import static com.madgag.agit.sync.AccountAuthenticatorService.addAccount;
+import android.app.TimePickerDialog;
+import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.preference.ListPreference;
+import android.preference.Preference;
 import android.preference.PreferenceActivity;
+import android.preference.PreferenceManager;
 import android.util.Log;
+import android.widget.TimePicker;
 
 public class SettingsActivity extends PreferenceActivity {
     public void onCreate(Bundle aSavedInstanceState) {
         super.onCreate(aSavedInstanceState);
         addPreferencesFromResource(R.layout.settings_activity);
+        ListPreference syncFreq = (ListPreference) findPreference(getString(R.string.setting_sync_frequency_key));
+        syncFreq.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object o) {
+                String value = (String)o;
+                if (value.equals(getString(R.string.setting_sync_frequency_daily))) {
+                    // Check if our previous value was the same thing, so we can set it in the time
+                    // picker dialog.
+                    final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(SettingsActivity.this);
+                    int hourDefault = 12;
+                    int minDefault = 0;
+                    String prevVal = prefs.getString(getString(R.string.setting_sync_frequency_key), "-1");
+                    if (prevVal.equals(o)) {
+                        hourDefault = prefs.getInt(getString(R.string.setting_sync_frequency_daily_hour_key), hourDefault);
+                        minDefault = prefs.getInt(getString(R.string.setting_sync_frequency_daily_min_key), minDefault);
+                    }
+
+                    TimePickerDialog.OnTimeSetListener timeListener = new TimePickerDialog.OnTimeSetListener() {
+                        @Override
+                        public void onTimeSet(TimePicker timePicker, int hourOfDay, int minOfHour) {
+                            SharedPreferences.Editor edtr = prefs.edit();
+                            edtr.putInt(getString(R.string.setting_sync_frequency_daily_hour_key), hourOfDay);
+                            edtr.putInt(getString(R.string.setting_sync_frequency_daily_min_key), minOfHour);
+                            edtr.commit();
+                        }
+                    };
+
+                    // Display new dialog with the available options.
+                    TimePickerDialog timePicker = new TimePickerDialog(SettingsActivity.this, timeListener, hourDefault, minDefault, false);
+                    timePicker.setTitle(getString(R.string.setting_sync_frequency_daily_title));
+                    timePicker.show();
+                }
+
+                return true;
+            }
+        });
     }
 
     @Override
@@ -40,5 +82,6 @@ public class SettingsActivity extends PreferenceActivity {
         }
     }
 
+    private ListPreference mSyncPreferences;
     private static final String TAG = "SettingsActivity";
 }

--- a/agit/src/main/java/com/madgag/agit/SettingsActivity.java
+++ b/agit/src/main/java/com/madgag/agit/SettingsActivity.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2011, 2012 Roberto Tyley
+ *
+ * This file is part of 'Agit' - an Android Git client.
+ *
+ * Agit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Agit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/ .
+ */
+
+package com.madgag.agit;
+
+import static com.madgag.agit.sync.AccountAuthenticatorService.addAccount;
+import android.os.Bundle;
+import android.preference.PreferenceActivity;
+import android.util.Log;
+
+public class SettingsActivity extends PreferenceActivity {
+    public void onCreate(Bundle aSavedInstanceState) {
+        super.onCreate(aSavedInstanceState);
+        addPreferencesFromResource(R.layout.settings_activity);
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        try {
+            addAccount(this);
+        } catch (Exception e) {
+            Log.w(TAG, "Unable to re-add account for syncing after preference changes", e);
+        }
+    }
+
+    private static final String TAG = "SettingsActivity";
+}

--- a/agit/src/main/java/com/madgag/agit/SettingsActivity.java
+++ b/agit/src/main/java/com/madgag/agit/SettingsActivity.java
@@ -30,6 +30,8 @@ import android.preference.PreferenceManager;
 import android.util.Log;
 import android.widget.TimePicker;
 
+import com.madgag.agit.sync.SyncRepoManager;
+
 public class SettingsActivity extends PreferenceActivity {
     public void onCreate(Bundle aSavedInstanceState) {
         super.onCreate(aSavedInstanceState);
@@ -58,6 +60,9 @@ public class SettingsActivity extends PreferenceActivity {
                             edtr.putInt(getString(R.string.setting_sync_frequency_daily_hour_key), hourOfDay);
                             edtr.putInt(getString(R.string.setting_sync_frequency_daily_min_key), minOfHour);
                             edtr.commit();
+
+                            SyncRepoManager manager = new SyncRepoManager();
+                            manager.setDailySync(SettingsActivity.this, hourOfDay, minOfHour);
                         }
                     };
 
@@ -65,6 +70,9 @@ public class SettingsActivity extends PreferenceActivity {
                     TimePickerDialog timePicker = new TimePickerDialog(SettingsActivity.this, timeListener, hourDefault, minDefault, false);
                     timePicker.setTitle(getString(R.string.setting_sync_frequency_daily_title));
                     timePicker.show();
+                } else {
+                    SyncRepoManager manager = new SyncRepoManager();
+                    manager.cancelDailySync(SettingsActivity.this);
                 }
 
                 return true;

--- a/agit/src/main/java/com/madgag/agit/sync/AccountAuthenticatorService.java
+++ b/agit/src/main/java/com/madgag/agit/sync/AccountAuthenticatorService.java
@@ -35,13 +35,10 @@ import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.content.res.Resources;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
 import android.util.Log;
-
-import com.madgag.agit.R;
 
 /**
  * Authenticator service that returns a subclass of AbstractAccountAuthenticator in onBind()
@@ -77,39 +74,27 @@ public class AccountAuthenticatorService extends Service {
             result.putString(AccountManager.KEY_ACCOUNT_TYPE, account.type);
         }
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ctx);
-        int syncFreq = Integer.parseInt(prefs.getString("setting_sync_frequency", "15"));
-
-        Resources res = ctx.getResources();
-        int dailySentinel = Integer.parseInt(res.getString(R.string.setting_sync_frequency_daily));
-        if (syncFreq == dailySentinel) {
-            int hourOfDay = prefs.getInt(res.getString(R.string.setting_sync_frequency_daily_hour_key), -1);
-            int minOfHour = prefs.getInt(res.getString(R.string.setting_sync_frequency_daily_min_key), -1);
-
-            Log.d(TAG, "Configuring sync to run at " + hourOfDay + "h" + minOfHour);
-            configureSyncFor(account, syncFreq, hourOfDay, minOfHour);
-        }
-
+        int syncFreq = Integer.parseInt(prefs.getString("setting_sync_frequency", "-1"));
         configureSyncFor(account, syncFreq);
+
         return result;
     }
 
     private static void configureSyncFor(Account aAccount, int aSyncFreq) {
-        configureSyncFor(aAccount, aSyncFreq, -1, -1);
-    }
-
-    private static void configureSyncFor(Account aAccount, int aSyncFreq, int aHourOfDay, int aMinOfHour) {
-
-        if (aSyncFreq < 1) {
+        // There are three possible sync settings we could have:
+        //  <  0: Indicates sync is disabled
+        //  == 0: Indicates sync is enabled, but it's handled by an alarm because it's a time-of-day sync
+        //  >  0: Indicates sync should be enabled for aSyncFreq minutes
+        if (aSyncFreq < 0) {
+            Log.d(TAG, "Disabling sync settings");
             setIsSyncable(aAccount, AGIT_PROVIDER_AUTHORITY, 0);
             ContentResolver.removePeriodicSync(aAccount, AGIT_PROVIDER_AUTHORITY, new Bundle());
-            return;
+        } else {
+            Log.d(TAG, "Trying to configure account for sync at rate of " + aSyncFreq + " minutes");
+            setIsSyncable(aAccount, AGIT_PROVIDER_AUTHORITY, 1);
+            setSyncAutomatically(aAccount, AGIT_PROVIDER_AUTHORITY, true);
+            ContentResolver.addPeriodicSync(aAccount, AGIT_PROVIDER_AUTHORITY, new Bundle(), (long) (aSyncFreq * 60));
         }
-
-
-        Log.d(TAG, "Trying to configure account for sync at rate of " + aSyncFreq + " minutes");
-        setIsSyncable(aAccount, AGIT_PROVIDER_AUTHORITY, 1);
-        setSyncAutomatically(aAccount, AGIT_PROVIDER_AUTHORITY, true);
-        ContentResolver.addPeriodicSync(aAccount, AGIT_PROVIDER_AUTHORITY, new Bundle(), (long) (aSyncFreq * 60));
     }
 
     private static class AccountAuthenticatorImpl extends AbstractAccountAuthenticator {

--- a/agit/src/main/java/com/madgag/agit/sync/AccountAuthenticatorService.java
+++ b/agit/src/main/java/com/madgag/agit/sync/AccountAuthenticatorService.java
@@ -81,6 +81,13 @@ public class AccountAuthenticatorService extends Service {
 
     private static void configureSyncFor(Account account, int syncFreq) {
         Log.d(TAG, "Trying to configure account for sync at rate of " + syncFreq + " minutes");
+
+        if (syncFreq < 1) {
+            setIsSyncable(account, AGIT_PROVIDER_AUTHORITY, 0);
+            ContentResolver.removePeriodicSync(account, AGIT_PROVIDER_AUTHORITY, new Bundle());
+            return;
+        }
+
         setIsSyncable(account, AGIT_PROVIDER_AUTHORITY, 1);
         setSyncAutomatically(account, AGIT_PROVIDER_AUTHORITY, true);
         ContentResolver.addPeriodicSync(account, AGIT_PROVIDER_AUTHORITY, new Bundle(), (long) (syncFreq * 60));

--- a/agit/src/main/java/com/madgag/agit/sync/AccountAuthenticatorService.java
+++ b/agit/src/main/java/com/madgag/agit/sync/AccountAuthenticatorService.java
@@ -34,8 +34,10 @@ import android.app.Service;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.IBinder;
+import android.preference.PreferenceManager;
 import android.util.Log;
 
 /**
@@ -71,15 +73,17 @@ public class AccountAuthenticatorService extends Service {
             result.putString(AccountManager.KEY_ACCOUNT_NAME, account.name);
             result.putString(AccountManager.KEY_ACCOUNT_TYPE, account.type);
         }
-        configureSyncFor(account);
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ctx);
+        int syncFreq = Integer.parseInt(prefs.getString("setting_sync_frequency", "15"));
+        configureSyncFor(account, syncFreq);
         return result;
     }
 
-    private static void configureSyncFor(Account account) {
-        Log.d(TAG, "Trying to configure account for sync...");
+    private static void configureSyncFor(Account account, int syncFreq) {
+        Log.d(TAG, "Trying to configure account for sync at rate of " + syncFreq + " minutes");
         setIsSyncable(account, AGIT_PROVIDER_AUTHORITY, 1);
         setSyncAutomatically(account, AGIT_PROVIDER_AUTHORITY, true);
-        ContentResolver.addPeriodicSync(account, AGIT_PROVIDER_AUTHORITY, new Bundle(), (long) (15 * 60));
+        ContentResolver.addPeriodicSync(account, AGIT_PROVIDER_AUTHORITY, new Bundle(), (long) (syncFreq * 60));
     }
 
     private static class AccountAuthenticatorImpl extends AbstractAccountAuthenticator {

--- a/agit/src/main/java/com/madgag/agit/sync/AccountAuthenticatorService.java
+++ b/agit/src/main/java/com/madgag/agit/sync/AccountAuthenticatorService.java
@@ -35,10 +35,13 @@ import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.res.Resources;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
 import android.util.Log;
+
+import com.madgag.agit.R;
 
 /**
  * Authenticator service that returns a subclass of AbstractAccountAuthenticator in onBind()
@@ -75,22 +78,38 @@ public class AccountAuthenticatorService extends Service {
         }
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ctx);
         int syncFreq = Integer.parseInt(prefs.getString("setting_sync_frequency", "15"));
+
+        Resources res = ctx.getResources();
+        int dailySentinel = Integer.parseInt(res.getString(R.string.setting_sync_frequency_daily));
+        if (syncFreq == dailySentinel) {
+            int hourOfDay = prefs.getInt(res.getString(R.string.setting_sync_frequency_daily_hour_key), -1);
+            int minOfHour = prefs.getInt(res.getString(R.string.setting_sync_frequency_daily_min_key), -1);
+
+            Log.d(TAG, "Configuring sync to run at " + hourOfDay + "h" + minOfHour);
+            configureSyncFor(account, syncFreq, hourOfDay, minOfHour);
+        }
+
         configureSyncFor(account, syncFreq);
         return result;
     }
 
-    private static void configureSyncFor(Account account, int syncFreq) {
-        Log.d(TAG, "Trying to configure account for sync at rate of " + syncFreq + " minutes");
+    private static void configureSyncFor(Account aAccount, int aSyncFreq) {
+        configureSyncFor(aAccount, aSyncFreq, -1, -1);
+    }
 
-        if (syncFreq < 1) {
-            setIsSyncable(account, AGIT_PROVIDER_AUTHORITY, 0);
-            ContentResolver.removePeriodicSync(account, AGIT_PROVIDER_AUTHORITY, new Bundle());
+    private static void configureSyncFor(Account aAccount, int aSyncFreq, int aHourOfDay, int aMinOfHour) {
+
+        if (aSyncFreq < 1) {
+            setIsSyncable(aAccount, AGIT_PROVIDER_AUTHORITY, 0);
+            ContentResolver.removePeriodicSync(aAccount, AGIT_PROVIDER_AUTHORITY, new Bundle());
             return;
         }
 
-        setIsSyncable(account, AGIT_PROVIDER_AUTHORITY, 1);
-        setSyncAutomatically(account, AGIT_PROVIDER_AUTHORITY, true);
-        ContentResolver.addPeriodicSync(account, AGIT_PROVIDER_AUTHORITY, new Bundle(), (long) (syncFreq * 60));
+
+        Log.d(TAG, "Trying to configure account for sync at rate of " + aSyncFreq + " minutes");
+        setIsSyncable(aAccount, AGIT_PROVIDER_AUTHORITY, 1);
+        setSyncAutomatically(aAccount, AGIT_PROVIDER_AUTHORITY, true);
+        ContentResolver.addPeriodicSync(aAccount, AGIT_PROVIDER_AUTHORITY, new Bundle(), (long) (aSyncFreq * 60));
     }
 
     private static class AccountAuthenticatorImpl extends AbstractAccountAuthenticator {

--- a/agit/src/main/java/com/madgag/agit/sync/SyncAdapter.java
+++ b/agit/src/main/java/com/madgag/agit/sync/SyncAdapter.java
@@ -25,6 +25,7 @@ import android.content.ContentProviderClient;
 import android.content.Context;
 import android.content.SyncResult;
 import android.os.Bundle;
+import android.util.Log;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -50,6 +51,7 @@ class SyncAdapter extends AbstractThreadedSyncAdapter {
     @Override
     public void onPerformSync(Account account, Bundle extras, String authority, ContentProviderClient provider,
                               SyncResult syncResult) {
+        Log.d(TAG, "Performing sync");
         cancelAnyCurrentCampaign();
         contextScope.enter(getContext());
         try {

--- a/agit/src/main/java/com/madgag/agit/sync/SyncRepoManager.java
+++ b/agit/src/main/java/com/madgag/agit/sync/SyncRepoManager.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2011, 2012 Roberto Tyley
+ *
+ * This file is part of 'Agit' - an Android Git client.
+ *
+ * Agit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Agit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/ .
+ */
+
+package com.madgag.agit.sync;
+
+import static com.madgag.agit.sync.Constants.AGIT_ACCOUNT_NAME;
+import static com.madgag.agit.sync.Constants.AGIT_ACCOUNT_TYPE;
+import static com.madgag.agit.sync.Constants.AGIT_PROVIDER_AUTHORITY;
+import android.accounts.Account;
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+
+import java.util.Calendar;
+import java.util.TimeZone;
+
+/**
+ * Manager class for daily synchronization settings. Because periodic sync at time-of-day intervals is handled
+ * differently than periodic sync on a regular schedule, we use this class as a receiver of alerts on a regular
+ * interval from AlarmManager.
+ */
+public class SyncRepoManager extends BroadcastReceiver {
+
+    public SyncRepoManager() {
+
+    }
+
+    /**
+     * Setup a sync at a specific hour and minute of the day. Every effort is made to make the sync happen at the time
+     * of day specified, but it's not guaranteed. Because we use inexact repeating alarms, it will never happen before
+     * the specified time, but it may happen quite a while afterwards. This is because the Android operating system
+     * tries to phase alarms so they don't happen at the same time.
+     *
+     * @param aContext The context from which the daily sync is being set up.
+     * @param aHour The hour of the day (from 0 to 24) at which the sync should happen
+     * @param aMin The minute of the hour at which the sync should happen.
+     */
+    public static void setDailySync(Context aContext, int aHour, int aMin) {
+        AlarmManager mgr =(AlarmManager)aContext.getSystemService(Context.ALARM_SERVICE);
+        Intent intent = new Intent("com.madgag.agit.sync.SET_DAILY_SYNC");
+        PendingIntent pend = PendingIntent.getBroadcast(aContext, 0, intent, 0);
+
+        Calendar updateTime = Calendar.getInstance();
+        updateTime.setTimeZone(TimeZone.getDefault());
+        updateTime.set(Calendar.HOUR_OF_DAY, aHour);
+        updateTime.set(Calendar.MINUTE, aMin);
+        long msTimeToRepeat = updateTime.getTimeInMillis();
+
+        mgr.setInexactRepeating(AlarmManager.RTC_WAKEUP, msTimeToRepeat, AlarmManager.INTERVAL_DAY, pend);
+    }
+
+    /**
+     * Cancel a daily sync already set up.
+     *
+     * @param aContext The context from which the daily sync cancellation is being requested.
+     */
+    public static void cancelDailySync(Context aContext) {
+        Log.d(TAG, "Canceling daily sync");
+        AlarmManager mgr =(AlarmManager)aContext.getSystemService(Context.ALARM_SERVICE);
+        Intent intent = new Intent("com.madgag.agit.sync.SET_DAILY_SYNC");
+        PendingIntent pend = PendingIntent.getBroadcast(aContext, 0, intent, 0);
+        mgr.cancel(pend);
+    }
+
+    @Override
+    public void onReceive(Context aContext, Intent aIntent) {
+        Calendar rightNow = Calendar.getInstance();
+        long timeInMs = rightNow.getTimeInMillis();
+        long offset = rightNow.get(Calendar.ZONE_OFFSET) +
+                rightNow.get(Calendar.DST_OFFSET);
+        long sinceMidnight = (rightNow.getTimeInMillis() + offset) %
+                (24 * 60 * 60 * 1000);
+        int hoursSinceMidnight = (int)(sinceMidnight / (60*60*1000));
+        boolean isPM = hoursSinceMidnight > 12;
+        int clockHour = hoursSinceMidnight % 12;
+        int minutesSinceMidnight = (int)((sinceMidnight % (hoursSinceMidnight * (60 * 60 * 1000))) / (60*1000));
+
+        long msAtMidnight = (rightNow.getTimeInMillis() + offset) - sinceMidnight;
+
+        Log.d(TAG, "onReceive called at " + clockHour + ":" + minutesSinceMidnight + " " + (isPM ? "pm" : "am"));
+        doSyncNow();
+    }
+
+    /**
+     * Triggers a manual synchronization of the repositories. This the main event that is performed
+     * after onReceive() is seen.
+     */
+    private void doSyncNow() {
+        Bundle settingsBundle = new Bundle();
+        settingsBundle.putBoolean(
+                ContentResolver.SYNC_EXTRAS_MANUAL, true);
+        settingsBundle.putBoolean(
+                ContentResolver.SYNC_EXTRAS_EXPEDITED, true);
+
+        Account account = new Account(AGIT_ACCOUNT_NAME, AGIT_ACCOUNT_TYPE);
+        ContentResolver.requestSync(account, AGIT_PROVIDER_AUTHORITY, settingsBundle);
+    }
+
+    private static final String TAG = "SyncRepoManager";
+}

--- a/agit/src/main/java/com/madgag/agit/sync/SyncRepoManager.java
+++ b/agit/src/main/java/com/madgag/agit/sync/SyncRepoManager.java
@@ -86,7 +86,6 @@ public class SyncRepoManager extends BroadcastReceiver {
     @Override
     public void onReceive(Context aContext, Intent aIntent) {
         Calendar rightNow = Calendar.getInstance();
-        long timeInMs = rightNow.getTimeInMillis();
         long offset = rightNow.get(Calendar.ZONE_OFFSET) +
                 rightNow.get(Calendar.DST_OFFSET);
         long sinceMidnight = (rightNow.getTimeInMillis() + offset) %
@@ -95,8 +94,6 @@ public class SyncRepoManager extends BroadcastReceiver {
         boolean isPM = hoursSinceMidnight > 12;
         int clockHour = hoursSinceMidnight % 12;
         int minutesSinceMidnight = (int)((sinceMidnight % (hoursSinceMidnight * (60 * 60 * 1000))) / (60*1000));
-
-        long msAtMidnight = (rightNow.getTimeInMillis() + offset) - sinceMidnight;
 
         Log.d(TAG, "onReceive called at " + clockHour + ":" + minutesSinceMidnight + " " + (isPM ? "pm" : "am"));
         doSyncNow();


### PR DESCRIPTION
I added a new 'Settings' menu to the Dashboard Activity which contains a single preference: the frequency, in minutes, of how often to synchronize repositories.

This works, but it's sort of a first pass at fixing this problem. Ideally, I think it would be nice to be able to sync with different options (e.g. every X minutes/hours, once per week, once a day, X day of the month, etc..). This is possible right now, but it requires that the user calculate the sync frequency to minutes, which is rather tedious for longer-term syncs.
